### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,10 +6,10 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-LedSyncClass  KEYWORD1
-NeoPixel  KEYWORD1
+LedSyncClass	KEYWORD1
+NeoPixel	KEYWORD1
 Color	KEYWORD1
-Led KEYWORD1
+Led	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords